### PR TITLE
Use sampling without replacement when choosing prompts

### DIFF
--- a/lpp/backend.py
+++ b/lpp/backend.py
@@ -94,7 +94,6 @@ class PromptsManager:
             factor = n // len(raw_tags) + 1 # +1 because // rounds down
             raw_tags = self.tag_data.raw_tags * factor
         chosen_prompts = sample(raw_tags, k=n)
-        assert(len(chosen_prompts) == n)
 
         source = self.tag_data.source
         format_func = self.__sm.sources[source].formatters[model]

--- a/lpp/backend.py
+++ b/lpp/backend.py
@@ -4,7 +4,7 @@ from lpp.log import get_logger
 from lpp.sources import TagSourceBase
 from lpp.utils import TagData, glob_match
 from os import path
-from random import choices
+from random import sample
 import json
 import pickle
 import re
@@ -87,7 +87,14 @@ class PromptsManager:
                        n: int = 1,
                        tag_filter_str: str = ""
                        ) -> list[list[str]]:
-        chosen_prompts = choices(self.tag_data.raw_tags, k=n)
+        raw_tags = self.tag_data.raw_tags
+        # manually handle requests for more images than we have tags
+        # because random.sample would raise a ValueError
+        if n > len(raw_tags):
+            factor = n // len(raw_tags) + 1 # +1 because // rounds down
+            raw_tags = self.tag_data.raw_tags * factor
+        chosen_prompts = sample(raw_tags, k=n)
+        assert(len(chosen_prompts) == n)
 
         source = self.tag_data.source
         format_func = self.__sm.sources[source].formatters[model]


### PR DESCRIPTION
When I downloaded 100 prompts and ran a batch of 64 generations, I expected every generation to be unique. Instead I got some images with repeat prompts.

This is due to the random prompt selection via [`random.choices`](https://docs.python.org/3.8/library/random.html#random.choices) selecting _with replacement,_ allowing the same prompt to be picked multiple times.

This PR changes the code to use [`random.sample`](https://docs.python.org/3.8/library/random.html#random.sample) that selects without replacement. We also explicitly handle the case where the number of prompts is smaller than the batch size, so that this configuration will keep working.